### PR TITLE
parser should consider cookies ending with no ";"

### DIFF
--- a/ts.cc
+++ b/ts.cc
@@ -115,6 +115,10 @@ void Cookies::parse(const util::StringView & s) {
       break;
     }
   }
+  if (i < j) {
+    map_[util::StringView(i, j - i)]
+      .push_back(util::StringView(j + 1, k - j - 1));
+  }
 }
 
 Cookies::Result Cookies::operator [] (


### PR DESCRIPTION
@sc0ttbeardsley 
