### PR TITLE
relaxing query parameter values to be 0 size long

### DIFF
--- a/ts-impl.cc
+++ b/ts-impl.cc
@@ -157,7 +157,7 @@ bool Loop(const typename T::Result & r, const U & u) {
   Iterator it = r.first->begin();
   for (; it != end; ++it) {
     ASSERT(it->pointer != NULL);
-    ASSERT(it->length > 0);
+    ASSERT(it->length >= 0);
     if (u(it)) {
       return true;
     }

--- a/ts.cc
+++ b/ts.cc
@@ -143,7 +143,7 @@ void QueryParameters::push(const char * const i,
     j = k;
   }
   Values & v = map_[util::StringView(i, j - i)];
-  if (j + 1 < k) {
+  if (j + 1 <= k) {
     v.push_back(util::StringView(j + 1, k - j - 1));
   }
 }


### PR DESCRIPTION
@sc0ttbeardsley relaxing query-parameters to be 0 size. Helps on test the equality for empty strings `/search?p=&n=10` 
